### PR TITLE
Update liquibase-core to 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [1.1.0]
+
+### Changed
+- The liquibase library to version `3.6.1` from `3.5.3`. This will recalculate hashes, see:
+https://www.liquibase.org/2018/04/liquibase-3-6-0-released.html
+
+## [1.0.1]
+
+### Added
+- Cross build for scala 2.11 and 2.12
+
+## [1.0.0]
+
+### Added
+- Support for sbt 1.0.x
+
+[1.1.0]: https://github.com/permutive/sbt-liquibase-plugin/compare/1.0.1...1.1.0
+[1.0.1]: https://github.com/permutive/sbt-liquibase-plugin/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/permutive/sbt-liquibase-plugin/compare/v0.2.0...1.0.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following to your `project/plugins.sbt`:
 
 ## sbt-(0.13.16 / 1.0.x)
 
-    addSbtPlugin("com.permutive" % "sbt-liquibase" % "1.0.0")
+    addSbtPlugin("com.permutive" % "sbt-liquibase" % "1.1.0")
 
 ### Step 2: Activate sbt-liquibase-plugin in your build
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,5 +42,5 @@ lazy val sbtLiquibase = Project(
   .enablePlugins(ScriptedPlugin)
   .settings(buildSettings)
   .settings(
-    libraryDependencies += "org.liquibase" % "liquibase-core" % "3.5.3",
+    libraryDependencies += "org.liquibase" % "liquibase-core" % "3.6.1"
   )

--- a/src/sbt-test/basic/update/build.sbt
+++ b/src/sbt-test/basic/update/build.sbt
@@ -1,5 +1,4 @@
 import java.sql.{Connection, DriverManager}
-import com.permutive.sbtliquibase.SbtLiquibase
 
 lazy val multipleTasks = taskKey[Unit]("Check multiple tasks running")
 
@@ -22,7 +21,7 @@ lazy val test = (project in file("."))
 
     multipleTasks := {},
 
-    multipleTasks <<= multipleTasks.dependsOn(Def.sequential(
+    multipleTasks := multipleTasks.dependsOn(Def.sequential(
       liquibaseDropAll,
       liquibaseUpdate
     ))

--- a/src/sbt-test/basic/update/project/plugins.sbt
+++ b/src/sbt-test/basic/update/project/plugins.sbt
@@ -13,10 +13,10 @@
          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
   }
 
-  else addSbtPlugin("com.github.sbtliquibase" % "sbt-liquibase" % pluginVersion)
+  else addSbtPlugin("com.permutive" % "sbt-liquibase" % pluginVersion)
 }
 
 libraryDependencies ++= Seq(
   "com.h2database" % "h2" % "1.4.182",
-  "org.liquibase" % "liquibase-core" % "3.5.3"
+  "org.liquibase" % "liquibase-core" % "3.6.1"
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0"
+version in ThisBuild := "1.0.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.2-SNAPSHOT"
+version in ThisBuild := "1.1.0"


### PR DESCRIPTION
Fixes bugs present in liquibase 3.5.3:
* https://liquibase.jira.com/browse/CORE-2978
* And a separate bug (I can not find a ticket) where the schema was not
quoted properly so addAutoIncrement would lead to an error

This change will recalculate the hashes so needs to be run against a DB
with no known changes:
https://www.liquibase.org/2018/04/liquibase-3-6-0-released.html

Also fix:
* `sbt-scripted` tests not testing this plugin
* Using removed sbt features to assing task keys